### PR TITLE
Allow indexing fields with arrays as values.

### DIFF
--- a/lib/curator/riak/data_store.rb
+++ b/lib/curator/riak/data_store.rb
@@ -25,8 +25,8 @@ module Curator
         object = ::Riak::RObject.new(bucket, options[:key])
         object.content_type = options.fetch(:content_type, "application/json")
         object.data = options[:value]
-        options.fetch(:index, {}).each do |index_name, index_value|
-          object.indexes["#{index_name}_bin"] << index_value
+        options.fetch(:index, {}).each do |index_name, index_data|
+          object.indexes["#{index_name}_bin"] << _normalized_index_data(index_data)
         end
         result = object.store
         result.key
@@ -68,6 +68,14 @@ module Curator
 
       def self._find_key_by_index(bucket, index_name, query)
         bucket.get_index("#{index_name}_bin", query)
+      end
+
+      def self._normalized_index_data(index_data)
+        if index_data.is_a?(Array)
+          index_data.join(", ")
+        else
+          index_data
+        end
       end
     end
   end

--- a/spec/curator/repository_spec.rb
+++ b/spec/curator/repository_spec.rb
@@ -28,6 +28,20 @@ describe Curator::Repository do
       repository.find_first_by_some_field("Acme Inc.").should == model
     end
 
+    it "can index arrays of values" do
+      repository = test_repository do
+        indexed_fields :multiple_values
+      end
+
+      model = TestModel.new(:multiple_values => ["first", "second"])
+
+      repository.save(model)
+
+      repository.find_by_multiple_values("first").should == [model]
+      repository.find_by_multiple_values("second").should == [model]
+      repository.find_by_multiple_values("third").should == []
+    end
+
     it "indexes created_at and updated_at by default" do
       repository = test_repository do
       end

--- a/spec/curator/shared_data_store_specs.rb
+++ b/spec/curator/shared_data_store_specs.rb
@@ -40,6 +40,19 @@ shared_examples "data_store" do |data_store|
       keys = data_store.find_by_index("test_collection", :indexed_key, "indexed+value").map { |data| data[:key] }
       keys.sort.should == ["key1"]
     end
+
+    it "can find objects by index with an array index" do
+      data_store.save(
+        :collection_name => "test_collection",
+        :key => "key1",
+        :value => {:indexed_key => ["indexed_value1", "indexed_value2"]},
+        :index => {:indexed_key => ["indexed_value1", "indexed_value2"]}
+      )
+
+      data_store.find_by_index("test_collection", :indexed_key, "indexed_value1").map { |data| data[:key] }.should == ["key1"]
+      data_store.find_by_index("test_collection", :indexed_key, "indexed_value2").map { |data| data[:key] }.should == ["key1"]
+      data_store.find_by_index("test_collection", :indexed_key, "indexed_value3").map { |data| data[:key] }.should == []
+    end
   end
 
   describe "find_by_key" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ end
 
 class TestModel
   include Curator::Model
-  attr_reader :id, :some_field
+  attr_reader :id, :some_field, :multiple_values
 end
 
 def test_repository(&block)


### PR DESCRIPTION
This pull request allows the value of indexed fields to be arrays.

If the indexed field has an array value, the records will be returned if any of the values in the array matches the search criteria.
