### PR TITLE
Rename find_by_index to find_by_attribute

### DIFF
--- a/lib/curator/memory/data_store.rb
+++ b/lib/curator/memory/data_store.rb
@@ -51,10 +51,10 @@ module Curator
         {:key => key, :data => value}
       end
 
-      def self.find_by_index(collection_name, index_name, query)
+      def self.find_by_attribute(collection_name, attribute, query)
         return [] if query.nil?
         bucket = _bucket_name(collection_name)
-        index = _index(bucket, index_name)
+        index = _index(bucket, attribute)
         keys = case query
                when Range
                  keys = index.keys.select do |key|

--- a/lib/curator/mongo/data_store.rb
+++ b/lib/curator/mongo/data_store.rb
@@ -41,7 +41,7 @@ module Curator
         collection.remove(:_id => id)
       end
 
-      def self.find_by_index(collection_name, field, query)
+      def self.find_by_attribute(collection_name, field, query)
         return [] if query.nil?
 
         exp = {}

--- a/lib/curator/repository.rb
+++ b/lib/curator/repository.rb
@@ -34,15 +34,15 @@ module Curator
       end
 
       def find_by_created_at(start_time, end_time)
-        _find_by_index(collection_name, :created_at, _format_time_for_index(start_time).._format_time_for_index(end_time))
+        _find_by_attribute(:created_at, _format_time_for_index(start_time).._format_time_for_index(end_time))
       end
 
       def find_by_updated_at(start_time, end_time)
-        _find_by_index(collection_name, :updated_at, _format_time_for_index(start_time).._format_time_for_index(end_time))
+        _find_by_attribute(:updated_at, _format_time_for_index(start_time).._format_time_for_index(end_time))
       end
 
       def find_by_version(version)
-        _find_by_index(collection_name, :version, version)
+        _find_by_attribute(:version, version)
       end
 
       def find_by_id(id)
@@ -93,20 +93,20 @@ module Curator
         object.instance_values
       end
 
-      def _build_finder_methods(field_name)
+      def _build_finder_methods(attribute)
         eigenclass = class << self; self; end
         eigenclass.class_eval do
-          define_method("find_by_#{field_name}") do |value|
-            _find_by_index(collection_name, field_name, value)
+          define_method("find_by_#{attribute}") do |value|
+            _find_by_attribute(attribute, value)
           end
-          define_method("find_first_by_#{field_name}") do |value|
-            _find_by_index(collection_name, field_name, value).first
+          define_method("find_first_by_#{attribute}") do |value|
+            _find_by_attribute(attribute, value).first
           end
         end
       end
 
-      def _find_by_index(collection_name, field_name, value)
-        if results = data_store.find_by_index(collection_name, field_name, value)
+      def _find_by_attribute(attribute, value)
+        if results = data_store.find_by_attribute(collection_name, attribute, value)
           results.map do |hash|
             _deserialize(hash[:key], hash[:data])
           end

--- a/lib/curator/riak/data_store.rb
+++ b/lib/curator/riak/data_store.rb
@@ -42,7 +42,7 @@ module Curator
         end
       end
 
-      def self.find_by_index(bucket_name, index_name, query)
+      def self.find_by_attribute(bucket_name, index_name, query)
         return [] if query.nil?
 
         bucket = _bucket(bucket_name)

--- a/spec/curator/memory/data_store_spec.rb
+++ b/spec/curator/memory/data_store_spec.rb
@@ -33,16 +33,16 @@ module Curator::Memory
       it 'deletes indexes for the key' do
         DataStore.save(:collection_name => 'heap', :key => 'some_key', :value => {'k' => 'v'}, :index => {:k => 'v'})
         DataStore.delete('heap', 'some_key')
-        DataStore.find_by_index('heap', :k, 'v').should be_empty
+        DataStore.find_by_attribute('heap', :k, 'v').should be_empty
       end
     end
 
-    describe 'self.find_by_index' do
+    describe 'self.find_by_attribute' do
       it 'returns objects with an indexed number value in a range' do
         DataStore.save(:collection_name => 'test_collection', :key => 'key1', :value => {:indexed_key => 1}, :index => {:indexed_key => 1})
         DataStore.save(:collection_name => 'test_collection', :key => 'key2', :value => {:indexed_key => 5}, :index => {:indexed_key => 5})
 
-        keys = DataStore.find_by_index('test_collection', :indexed_key, 0..2).map { |data| data[:key] }
+        keys = DataStore.find_by_attribute('test_collection', :indexed_key, 0..2).map { |data| data[:key] }
         keys.sort.should == ['key1']
       end
 
@@ -51,15 +51,15 @@ module Curator::Memory
         DataStore.save(:collection_name => 'test_collection', :key => 'key2', :value => {:indexed_key => 3.days.ago}, :index => {:indexed_key => 3.days.ago})
 
         range = (11.hours.from_now.utc..15.hours.from_now.utc)
-        keys = DataStore.find_by_index('test_collection', :indexed_key, range).map { |data| data[:key] }
+        keys = DataStore.find_by_attribute('test_collection', :indexed_key, range).map { |data| data[:key] }
         keys.sort.should == []
 
         range = (15.minutes.ago.utc..5.minutes.from_now.utc)
-        keys = DataStore.find_by_index('test_collection', :indexed_key, range).map { |data| data[:key] }
+        keys = DataStore.find_by_attribute('test_collection', :indexed_key, range).map { |data| data[:key] }
         keys.sort.should == ['key1']
 
         range = (10.days.ago.utc..4.days.from_now.utc)
-        keys = DataStore.find_by_index('test_collection', :indexed_key, range).map { |data| data[:key] }
+        keys = DataStore.find_by_attribute('test_collection', :indexed_key, range).map { |data| data[:key] }
         keys.sort.should == ['key1', 'key2']
       end
     end

--- a/spec/curator/shared_data_store_specs.rb
+++ b/spec/curator/shared_data_store_specs.rb
@@ -8,20 +8,20 @@ shared_examples "data_store" do |data_store|
     end
   end
 
-  describe "self.find_by_index" do
+  describe "self.find_by_attribute" do
     it "returns an empty array if key is not found" do
-      data_store.find_by_index("abyss","invalid_index","invalid_key").should be_empty
+      data_store.find_by_attribute("abyss","invalid_index","invalid_key").should be_empty
     end
 
     it "returns an empty array if key is nil" do
-      data_store.find_by_index("abyss","invalid_index", nil).should be_empty
+      data_store.find_by_attribute("abyss","invalid_index", nil).should be_empty
     end
 
     it "returns multiple objects" do
       data_store.save(:collection_name => "test_collection", :key => "key1", :value => {:indexed_key => "indexed_value"}, :index => {:indexed_key => "indexed_value"})
       data_store.save(:collection_name => "test_collection", :key => "key2", :value => {:indexed_key => "indexed_value"}, :index => {:indexed_key => "indexed_value"})
 
-      keys = data_store.find_by_index("test_collection", :indexed_key, "indexed_value").map { |data| data[:key] }
+      keys = data_store.find_by_attribute("test_collection", :indexed_key, "indexed_value").map { |data| data[:key] }
       keys.sort.should == ["key1", "key2"]
     end
 
@@ -29,15 +29,15 @@ shared_examples "data_store" do |data_store|
       data_store.save(:collection_name => "test_collection",  :key => "key1", :value => {:indexed_key => 'e'}, :index => {:indexed_key => 'e'})
       data_store.save(:collection_name => "test_collection",  :key => "key2", :value => {:indexed_key => 'g'}, :index => {:indexed_key => 'g'})
 
-      data_store.find_by_index("test_collection", :indexed_key, ('a'..'f')).map { |data| data[:key] }.should == ["key1"]
-      data_store.find_by_index("test_collection", :indexed_key, ('f'..'h')).map { |data| data[:key] }.should == ["key2"]
-      data_store.find_by_index("test_collection", :indexed_key, ('a'..'h')).map { |data| data[:key] }.sort.should == ["key1", "key2"]
+      data_store.find_by_attribute("test_collection", :indexed_key, ('a'..'f')).map { |data| data[:key] }.should == ["key1"]
+      data_store.find_by_attribute("test_collection", :indexed_key, ('f'..'h')).map { |data| data[:key] }.should == ["key2"]
+      data_store.find_by_attribute("test_collection", :indexed_key, ('a'..'h')).map { |data| data[:key] }.sort.should == ["key1", "key2"]
     end
 
     it "can find objects by index with a key containing a + character" do
       data_store.save(:collection_name => "test_collection", :key => "key1", :value => {:indexed_key => "indexed+value"}, :index => {:indexed_key => "indexed+value"})
 
-      keys = data_store.find_by_index("test_collection", :indexed_key, "indexed+value").map { |data| data[:key] }
+      keys = data_store.find_by_attribute("test_collection", :indexed_key, "indexed+value").map { |data| data[:key] }
       keys.sort.should == ["key1"]
     end
 
@@ -49,9 +49,9 @@ shared_examples "data_store" do |data_store|
         :index => {:indexed_key => ["indexed_value1", "indexed_value2"]}
       )
 
-      data_store.find_by_index("test_collection", :indexed_key, "indexed_value1").map { |data| data[:key] }.should == ["key1"]
-      data_store.find_by_index("test_collection", :indexed_key, "indexed_value2").map { |data| data[:key] }.should == ["key1"]
-      data_store.find_by_index("test_collection", :indexed_key, "indexed_value3").map { |data| data[:key] }.should == []
+      data_store.find_by_attribute("test_collection", :indexed_key, "indexed_value1").map { |data| data[:key] }.should == ["key1"]
+      data_store.find_by_attribute("test_collection", :indexed_key, "indexed_value2").map { |data| data[:key] }.should == ["key1"]
+      data_store.find_by_attribute("test_collection", :indexed_key, "indexed_value3").map { |data| data[:key] }.should == []
     end
   end
 
@@ -99,10 +99,10 @@ shared_examples "data_store" do |data_store|
         :index => {:foo => "foo-data", :bar => "bar-data"}
       )
 
-      foo_result = data_store.find_by_index("fake_things", :foo, "foo-data").first
+      foo_result = data_store.find_by_attribute("fake_things", :foo, "foo-data").first
       foo_result[:key].should == "blah"
 
-      bar_result = data_store.find_by_index("fake_things", :bar, "bar-data").first
+      bar_result = data_store.find_by_attribute("fake_things", :bar, "bar-data").first
       bar_result[:key].should == "blah"
     end
   end


### PR DESCRIPTION
I think this rename will make the Repository more DataStore agnostic. For example, the Mongo DataStore currently isn't aware of indexes explicitly like the Riak DataStore is. Instead, the Mongo implementation handles the index parameter as the attribute name to find by.
