### PR TITLE
[Fixes #23] symbolize keys for mongo yaml

### DIFF
--- a/lib/curator/mongo/data_store.rb
+++ b/lib/curator/mongo/data_store.rb
@@ -7,6 +7,8 @@ module Curator
       def client
         return @client if @client
         config = YAML.load(File.read(Curator.config.mongo_config_file))[Curator.config.environment]
+        config = config.symbolize_keys
+
         host = config.delete(:host)
         port = config.delete(:port)
         password = config.delete(:password)


### PR DESCRIPTION
It appears a default host and port are provided by Mongo::Connection in the event that nil parameters are provided for host and port, so I didn't touch that part.
