### PR TITLE
Manual client setup instead of using YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /tags
 *.gem
+.bundle
+vendor

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ Curator.configure(:riak) do |config|
 end
 ```
 
+Alternatively, instead of using a YAML file to configure the client you can set it manually.
+
+```ruby
+Curator.configure(:riak) do |config|
+  config.bucket_prefix = "my_app"
+  config.environment = "development"
+  config.migrations_path = File.expand_path(File.dirname(__FILE__) + "/../db/migrate")
+  config.client = Riak::Client.new
+end
+```
+
 ## Testing
 
 If you are writing tests using curator, it's likely that you will want a way to clean up your data in Riak between tests. Riak does not provide an easy way to clear out all data, so curator takes care of it for you. You can use the following methods if you change your backend from `:riak` to `:resettable_riak`:

--- a/lib/curator/configuration.rb
+++ b/lib/curator/configuration.rb
@@ -1,3 +1,3 @@
 module Curator::Configuration
-  attr_accessor :environment, :migrations_path
+  attr_accessor :environment, :migrations_path, :client
 end

--- a/lib/curator/mongo/data_store.rb
+++ b/lib/curator/mongo/data_store.rb
@@ -6,6 +6,13 @@ module Curator
     class DataStore
       def client
         return @client if @client
+
+        if Curator.config.client
+          @client        = Curator.config.client
+          @database_name = Curator.config.database
+          return @client
+        end
+
         config = YAML.load(File.read(Curator.config.mongo_config_file))[Curator.config.environment]
         config = config.symbolize_keys
 

--- a/lib/curator/riak/data_store.rb
+++ b/lib/curator/riak/data_store.rb
@@ -6,6 +6,8 @@ module Curator
     class DataStore
       def client
         return @client if @client
+        return @client = Curator.config.client if Curator.config.client
+
         yml_config = YAML.load(File.read(Curator.config.riak_config_file))[Curator.config.environment]
         @client = ::Riak::Client.new(yml_config)
       end

--- a/spec/curator/mongo/data_store_spec.rb
+++ b/spec/curator/mongo/data_store_spec.rb
@@ -20,6 +20,20 @@ module Curator
       end
 
       describe "self.client" do
+        context "with a client manually configured" do
+          with_config do
+            Curator.configure(:mongo) do |config|
+              config.environment = "test"
+              config.client      = ::Mongo::Connection.new
+              config.database    = "curator"
+            end
+          end
+
+          it "should return the client and not use the yaml file" do
+            data_store.client.should == Curator.config.client
+          end
+        end
+
         it "returns a mongo client with a config read from the yml file provided" do
           begin
             File.stub(:read).and_return(<<-YML)

--- a/spec/curator/riak/data_store_spec.rb
+++ b/spec/curator/riak/data_store_spec.rb
@@ -9,6 +9,19 @@ module Curator
       let(:data_store) { DataStore.new }
 
       describe "self.client" do
+        context "with a client manually configured" do
+          with_config do
+            Curator.configure(:resettable_riak) do |config|
+              config.environment = "test"
+              config.client      = ::Riak::Client.new
+            end
+          end
+
+          it "should return the client and not use the yaml file" do
+            data_store.client.should == Curator.config.client
+          end
+        end
+
         it "returns a riak client with a config read from the yml file provided" do
           begin
             File.should_receive(:read).and_return(<<-YML)


### PR DESCRIPTION
A riak or mongo client can now be manually instantiated and set in the
configure block. I also updated the README to reflect this option.
