### PR TITLE
The Mongo config should support auth via ENV variables

### DIFF
--- a/lib/curator/mongo/data_store.rb
+++ b/lib/curator/mongo/data_store.rb
@@ -13,6 +13,14 @@ module Curator
           return @client
         end
 
+        if ENV['MONGO_URI']
+          require 'uri'
+          uri = URI.parse(ENV['MONGO_URI'])
+          @database_name = uri.path.gsub(/^\//, '')
+          @client = ::Mongo::Connection.from_uri(uri.to_s)
+          return @client
+        end
+
         config = YAML.load(File.read(Curator.config.mongo_config_file))[Curator.config.environment]
         config = config.symbolize_keys
 

--- a/spec/curator/mongo/data_store_spec.rb
+++ b/spec/curator/mongo/data_store_spec.rb
@@ -141,6 +141,30 @@ module Curator
               data_store.instance_variable_set('@client', nil)
             end
           end
+
+          it "entire client and database configured by environment variable" do
+            begin
+              ENV['MONGO_URI'] = 'mongodb://my_username:password1@localhost:27017/test_db_auth'
+              File.stub(:read).and_return(<<-YML)
+              test:
+                :host: mongo.braintree.com
+                :port: 12345
+              YML
+              data_store.instance_variable_set('@client', nil)
+              client = data_store.client
+              client.host.should == 'localhost'
+              client.port.should == 27017
+              data_store._db_name.should == 'test_db_auth'
+              client.auths.should_not be_empty
+              client.auths[0]["db_name"].should == 'test_db_auth'
+              client.auths[0]["username"].should == 'my_username'
+              client.auths[0]["password"].should == 'password1'
+            ensure
+              client.remove_auth('test_db_auth')
+              ENV['MONGO_URI'] = nil
+              data_store.instance_variable_set('@client', nil)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Not every project will want to put their auth credentials for their Mongo database in a YML file, so we can try pulling the username and password from environment variables before falling back to the regular YML config spot.

This also made me realise that we could spit out both the `@database_name` and the `@client` instance variables by parsing the `MONGO_URI` environment variable.
