### PR TITLE
Build for Ruby 2.0.0 and 2.1.0 in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 rvm:
   - 1.9.2
   - 1.9.3
+  - 2.0.0
+  - 2.1.0
 services:
   - mongodb
   - riak


### PR DESCRIPTION
Add support for Ruby 2.0.0 and 2.1.0 in the Travis build.
