### PR TITLE
Add Settings to Memory DataStore

### DIFF
--- a/lib/curator/memory/data_store.rb
+++ b/lib/curator/memory/data_store.rb
@@ -3,6 +3,15 @@ require 'ostruct'
 module Curator
   module Memory
     class DataStore
+
+      def settings(bucket_name)
+        {}
+      end
+
+      def update_settings!(collection_name, updated_settings)
+        # NOOP
+      end
+
       def remove_all_keys
         @data = {}
       end

--- a/spec/curator/memory/data_store_spec.rb
+++ b/spec/curator/memory/data_store_spec.rb
@@ -16,6 +16,16 @@ module Curator::Memory
       end
     end
 
+    context "collection settings" do
+      it "returns empty settings" do
+        data_store.settings("test_bucket").should be_empty
+      end
+
+      it "update_settings does nothing" do
+        data_store.update_settings!("test_bucket", {})
+      end
+    end
+
     describe 'self.remove_all_keys' do
       it 'clears the data set' do
         data_store._data[:foo] = 1


### PR DESCRIPTION
Adds `settings` and `update_settings` methods to the `Memory::DataStore`.

These methods were added to the `Riak::DataStore` recently, and this change will allow us to use `Memory::DataStore` in test.

Related to: https://github.com/braintree/curator/pull/41/files
