### PR TITLE
Repository#_find_by_attribute to handle the case where the data is nil

### DIFF
--- a/lib/curator/repository.rb
+++ b/lib/curator/repository.rb
@@ -132,8 +132,8 @@ module Curator
       def _find_by_attribute(attribute, value)
         if results = data_store.find_by_attribute(collection_name, attribute, value)
           results.map do |hash|
-            _deserialize(hash[:key], hash[:data])
-          end
+            _deserialize(hash[:key], hash[:data]) if hash
+          end.compact
         end
       end
 

--- a/spec/curator/repository_spec.rb
+++ b/spec/curator/repository_spec.rb
@@ -230,6 +230,22 @@ describe Curator::Repository do
 
         TestModelRepository.find_by_some_field("Doesn't exist").should == []
       end
+
+      it "returns empty array if data store returns an array with a nil element" do
+        def_transient_class(:TestModelRepository) do
+          include Curator::Repository
+          attr_reader :id, :some_field
+          indexed_fields :some_field
+        end
+
+        def_transient_class(:TestModel) do
+          include Curator::Model
+          attr_reader :id, :some_field
+        end
+
+        TestModelRepository.data_store.stub(:find_by_attribute).and_return([nil])
+        TestModelRepository.find_by_some_field("Doesn't exist").should == []
+      end
     end
 
     context "find_first_by_index" do


### PR DESCRIPTION
Updated Repository._find_by_attribute to handle the case where the data store returns an array with a nil element in it.

Background:
We came across cases where a nil element is returned when Repository#_find_by_attribute is called. We believe this has to do with the fact what we have tombstones in our Riak store. We added a nil check before trying to access [:key] and [:data] to prevent an exception from being thrown.
