### PR TITLE
Fix default bucket names to work with newer activesupport versions

### DIFF
--- a/lib/curator/repository.rb
+++ b/lib/curator/repository.rb
@@ -32,7 +32,7 @@ module Curator
       end
 
       def default_collection_name
-        ActiveSupport::Inflector.tableize(klass)
+        ActiveSupport::Inflector.tableize(klass.name)
       end
 
       def data_store


### PR DESCRIPTION
Potential fix for https://github.com/braintree/curator/issues/50

@pgr0ss 