### PR TITLE
Revert breaking change that renames default config file name

### DIFF
--- a/lib/curator/railtie.rb
+++ b/lib/curator/railtie.rb
@@ -5,7 +5,7 @@ module Curator
         config.bucket_prefix = app.class.name.split("::").first.underscore
         config.environment = Rails.env
         config.migrations_path = Rails.root.join('db', 'migrate')
-        config.riak_config_file = Rails.root.join('config', 'riak_with_protobuf.yml')
+        config.riak_config_file = Rails.root.join('config', 'riak.yml')
       end
     end
 


### PR DESCRIPTION
@pgr0ss reverting this change from my previous PR. This breaks anyone using the default config file "riak.yml"

Could you merge and bump version please?