### PR TITLE
Pass Configuration objects to DataStore#initialize

### DIFF
--- a/lib/curator/memory/configuration.rb
+++ b/lib/curator/memory/configuration.rb
@@ -3,7 +3,7 @@ module Curator::Memory
     include Curator::Configuration
 
     def data_store
-      Curator::Memory::DataStore.new
+      Curator::Memory::DataStore.new(self)
     end
   end
 end

--- a/lib/curator/memory/data_store.rb
+++ b/lib/curator/memory/data_store.rb
@@ -3,6 +3,9 @@ require 'ostruct'
 module Curator
   module Memory
     class DataStore
+      def initialize(config = Curator.config)
+        @config = config
+      end
 
       def settings(bucket_name)
         {}
@@ -122,7 +125,7 @@ module Curator
       end
 
       def _bucket_name(name)
-        "#{Curator.config.environment}:#{name}"
+        "#{@config.environment}:#{name}"
       end
     end
   end

--- a/lib/curator/mongo/configuration.rb
+++ b/lib/curator/mongo/configuration.rb
@@ -5,7 +5,7 @@ module Curator::Mongo
     attr_accessor :database, :mongo_config_file
 
     def data_store
-      Curator::Mongo::DataStore.new
+      Curator::Mongo::DataStore.new(self)
     end
   end
 end

--- a/lib/curator/mongo/data_store.rb
+++ b/lib/curator/mongo/data_store.rb
@@ -4,12 +4,16 @@ require 'yaml'
 module Curator
   module Mongo
     class DataStore
+      def initializer(config = Curator.config)
+        @config = config
+      end
+
       def client
         return @client if @client
 
-        if Curator.config.client
-          @client        = Curator.config.client
-          @database_name = Curator.config.database
+        if @config.client
+          @client        = @config.client
+          @database_name = @config.database
           return @client
         end
 
@@ -21,7 +25,7 @@ module Curator
           return @client
         end
 
-        config = YAML.load(File.read(Curator.config.mongo_config_file))[Curator.config.environment]
+        config = YAML.load(File.read(@config.mongo_config_file))[@config.environment]
         config = config.symbolize_keys
 
         host = config.delete(:host)
@@ -107,7 +111,7 @@ module Curator
       end
 
       def default_db_name
-        "#{Curator.config.database}:#{Curator.config.environment}"
+        "#{@config.database}:#{@config.environment}"
       end
 
       def _db_name

--- a/lib/curator/mongo/data_store.rb
+++ b/lib/curator/mongo/data_store.rb
@@ -4,7 +4,7 @@ require 'yaml'
 module Curator
   module Mongo
     class DataStore
-      def initializer(config = Curator.config)
+      def initialize(config = Curator.config)
         @config = config
       end
 

--- a/lib/curator/resettable_riak/configuration.rb
+++ b/lib/curator/resettable_riak/configuration.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../riak/configuration')
 module Curator::ResettableRiak
   class Configuration < Curator::Riak::Configuration
     def data_store
-      Curator::ResettableRiak::DataStore.new
+      Curator::ResettableRiak::DataStore.new(self)
     end
   end
 end

--- a/lib/curator/resettable_riak/data_store.rb
+++ b/lib/curator/resettable_riak/data_store.rb
@@ -6,7 +6,7 @@ module Curator
     class DataStore < Riak::DataStore
       def bucket_prefix
         job = "#{ENV['JOB_NAME'].gsub(/[^[:alnum:]]/, '_')}" if ENV['JOB_NAME'].present?
-        [Curator.config.bucket_prefix, job, Curator.config.environment].compact.join(':')
+        [@config.bucket_prefix, job, @config.environment].compact.join(':')
       end
 
       def exclude_from_reset(&block)

--- a/lib/curator/riak/configuration.rb
+++ b/lib/curator/riak/configuration.rb
@@ -12,7 +12,7 @@ module Curator::Riak
     end
 
     def data_store
-      Curator::Riak::DataStore.new
+      Curator::Riak::DataStore.new(self)
     end
   end
 end

--- a/lib/curator/riak/data_store.rb
+++ b/lib/curator/riak/data_store.rb
@@ -4,16 +4,20 @@ require 'yaml'
 module Curator
   module Riak
     class DataStore
+      def initialize(config = Curator.config)
+        @config = config
+      end
+
       def client
         return @client if @client
-        return @client = Curator.config.client if Curator.config.client
+        return @client = @config.client if @config.client
 
-        yml_config = YAML.load(File.read(Curator.config.riak_config_file))[Curator.config.environment]
+        yml_config = YAML.load(File.read(@config.riak_config_file))[@config.environment]
         @client = ::Riak::Client.new(yml_config)
       end
 
       def bucket_prefix
-        "#{Curator.config.bucket_prefix}:#{Curator.config.environment}"
+        "#{@config.bucket_prefix}:#{@config.environment}"
       end
 
       def delete(bucket_name, key)


### PR DESCRIPTION
This is a first pass into separating the notion of Curator-wide configuration values from DataStore-local configuration values.

If we ever get to a point where one can have multiple instances of DataStore in-process, having them all contend for `Curator.config` becomes an issue.
